### PR TITLE
Add for control of leds over I2C

### DIFF
--- a/lib/nerves_grove/led.ex
+++ b/lib/nerves_grove/led.ex
@@ -13,9 +13,25 @@ defmodule Nerves.Grove.LED do
       LED.blink(pid)
   """
 
+  @i2c_read_command  1
+  @i2c_write_command 2
+  @i2c_mode_command  5
+
   @spec start_link(pos_integer) :: {:ok, pid} | {:error, any}
   def start_link(pin) when is_integer(pin) do
-    Gpio.start_link(pin, :output)
+    pins = Application.get_env(:nerves_grove, :pins, [])
+    { _, type, extra } = Enum.find(pins, fn {pn,backend} -> pn == pin end) || {pin, :gpio}
+
+    case type do
+      :gpio ->
+        {success, pid} = Gpio.start_link(pin, :output)
+        {success, {pid, :gpio, pin}}
+      :i2c ->
+        { fname, address } = extra
+        with {:ok, pid} <- I2c.start_link(fname, address),
+             :ok <- I2c.write(pid, <<@i2c_mode_command, pin, 1, 0>>),
+           do: {:ok, {pid, :i2c, pin}}
+    end    
   end
 
   @doc "Blinks the LED for a specified duration."
@@ -28,14 +44,24 @@ defmodule Nerves.Grove.LED do
   end
 
   @doc "Switches on the LED."
-  @spec on(pid) :: any
-  def on(pid) when is_pid(pid) do
-    Gpio.write(pid, 1)
+  @spec on({pid,Keyword.T,pos_integer}) :: any
+  def on(data) when is_tuple(data) do
+    {pid, type, pin} = data
+    case type do
+      :gpio -> Gpio.write(pid, 1)
+      :i2c  -> I2c.write(pid, <<@i2c_write_command, pin, 1, 0>>)
+      _     -> {:error, "Invalid line type"}
+    end
   end
 
   @doc "Switches off the LED."
-  @spec off(pid) :: any
-  def off(pid) when is_pid(pid) do
-    Gpio.write(pid, 0)
+  @spec off({pid, Keyword.T, pos_integer}) :: any
+  def off(data) when is_tuple(data) do
+    {pid, type, pin} = data
+    case type do
+      :gpio -> Gpio.write(pin, 1)
+      :i2c  -> I2c.write(pid, <<@i2c_write_command, pin, 0, 0>>)
+      _     -> {:error, "Invalid line type"}
+    end
   end
 end

--- a/lib/nerves_grove/led.ex
+++ b/lib/nerves_grove/led.ex
@@ -13,14 +13,14 @@ defmodule Nerves.Grove.LED do
       LED.blink(pid)
   """
 
-  @i2c_read_command  1
-  @i2c_write_command 2
+  @i2c_digital_read_command  1
+  @i2c_digital_write_command 2
   @i2c_mode_command  5
 
   @spec start_link(pos_integer) :: {:ok, pid} | {:error, any}
   def start_link(pin) when is_integer(pin) do
     pins = Application.get_env(:nerves_grove, :pins, [])
-    { _, type, extra } = Enum.find(pins, fn {pn,backend} -> pn == pin end) || {pin, :gpio}
+    { _, type, extra } = Enum.find(pins, fn {pn,_,_} -> pn == pin end) || {pin, :gpio, nil}
 
     case type do
       :gpio ->
@@ -49,7 +49,7 @@ defmodule Nerves.Grove.LED do
     {pid, type, pin} = data
     case type do
       :gpio -> Gpio.write(pid, 1)
-      :i2c  -> I2c.write(pid, <<@i2c_write_command, pin, 1, 0>>)
+      :i2c  -> I2c.write(pid, <<@i2c_digital_write_command, pin, 1, 0>>)
       _     -> {:error, "Invalid line type"}
     end
   end
@@ -60,7 +60,7 @@ defmodule Nerves.Grove.LED do
     {pid, type, pin} = data
     case type do
       :gpio -> Gpio.write(pin, 1)
-      :i2c  -> I2c.write(pid, <<@i2c_write_command, pin, 0, 0>>)
+      :i2c  -> I2c.write(pid, <<@i2c_digital_write_command, pin, 0, 0>>)
       _     -> {:error, "Invalid line type"}
     end
   end

--- a/lib/nerves_grove/led.ex
+++ b/lib/nerves_grove/led.ex
@@ -35,8 +35,8 @@ defmodule Nerves.Grove.LED do
   end
 
   @doc "Blinks the LED for a specified duration."
-  @spec blink(pid, number) :: any
-  def blink(pid, duration \\ 0.2) when is_pid(pid) and is_number(duration) do
+  @spec blink({pid, Keyword.T, pos_integer}, number) :: any
+  def blink(data, duration \\ 0.2) when is_tuple(data) and is_number(duration) do
     duration_in_ms = duration * 1000 |> round
     on(pid)
     :timer.sleep(duration_in_ms)

--- a/lib/nerves_grove/led.ex
+++ b/lib/nerves_grove/led.ex
@@ -38,9 +38,9 @@ defmodule Nerves.Grove.LED do
   @spec blink({pid, Keyword.T, pos_integer}, number) :: any
   def blink(data, duration \\ 0.2) when is_tuple(data) and is_number(duration) do
     duration_in_ms = duration * 1000 |> round
-    on(pid)
+    on(data)
     :timer.sleep(duration_in_ms)
-    off(pid)
+    off(data)
   end
 
   @doc "Switches on the LED."


### PR DESCRIPTION
The Grove extension board has some GPIO ports that are behind an I2C bus (which is the one that they document). I'm using `config pins: []` to specify what is the backend for controlling the GPIO.

I had to change the return type of `start_link` from `pid` to `{pid, :type, pin}` and I'm not very satisfied with it, however I figured that should help getting the discussion started, while I cover other drivers and come up with a cleaner solution.
